### PR TITLE
Update package version of the node to be properly fetched by client

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	version = "0.0.1"
+	version = "0.14.4"
 )
 
 func main() {


### PR DESCRIPTION
When running a remote node built from source, the client shows a 0.0.1 version since the package version of the go package does not reflect the actual released version. I suggest you update this version every time before making a release, so that it shows up properly in all clients.
