### PR TITLE
Add bcn_feePerByte and bcn_sendRawTX to API

### DIFF
--- a/api/blockchain_api.go
+++ b/api/blockchain_api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/idena-network/idena-go/core/mempool"
 	"github.com/idena-network/idena-go/ipfs"
 	"github.com/idena-network/idena-go/protocol"
+	"github.com/idena-network/idena-go/rlp"
 	"github.com/ipfs/go-cid"
 	"github.com/shopspring/decimal"
 	"math/big"
@@ -196,6 +197,19 @@ func (api *BlockchainApi) PendingTransactions(args TransactionsArgs) Transaction
 		Transactions: list,
 		Token:        nil,
 	}
+}
+
+func (api *BlockchainApi) FeePerByte() *big.Int {
+	return api.baseApi.getAppState().State.FeePerByte()
+}
+
+func (api *BlockchainApi) SendRawTX(bytesTX hexutil.Bytes) (common.Hash, error) {
+	var tx types.Transaction
+	if err := rlp.DecodeBytes(bytesTX, &tx); err != nil {
+		return common.Hash{}, err
+	}
+
+	return api.baseApi.sendInternalTx(&tx)
 }
 
 func (api *BlockchainApi) Transactions(args TransactionsArgs) Transactions {


### PR DESCRIPTION
In order to do raw transaction signing it would be very convenient if these could get merged. Happy to touch them up if they're not to style standards.