### PR TITLE
[WIP] Modify node to print signature of epoch state and merkle path when killing an invitee

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -848,6 +848,9 @@ func (chain *Blockchain) ApplyTxOnState(appState *appstate.AppState, tx *types.T
 			(inviteePrevState == state.Invite || inviteePrevState == state.Candidate) {
 			stateDB.AddInvite(sender, 1)
 		}
+		invitingMerkleTreePath, _, _ := offlineDetector.invitingMerkleTree.GetMerklePath(InvitingMerkleTreeContent{h: sender.Bytes()})
+		// This needs to be passed to the Ethereum-Idena Relayer
+		fmt.Println(invitingMerkleTreePath)
 	case types.SubmitFlipTx:
 		stateDB.SubBalance(sender, fee)
 		stateDB.SubBalance(sender, tx.TipsOrZero())

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -848,9 +848,11 @@ func (chain *Blockchain) ApplyTxOnState(appState *appstate.AppState, tx *types.T
 			(inviteePrevState == state.Invite || inviteePrevState == state.Candidate) {
 			stateDB.AddInvite(sender, 1)
 		}
-		invitingMerkleTreePath, _, _ := chain.offlineDetector.invitingMerkleTree.GetMerklePath(InvitingMerkleTreeContent{h: sender.Bytes()})
-		// This needs to be passed to the Ethereum-Idena Relayer
-		fmt.Println(invitingMerkleTreePath)
+		if t := chain.offlineDetector.invitingMerkleTree; t != nil {
+			invitingMerkleTreePath, _, _ := t.GetMerklePath(InvitingMerkleTreeContent{h: sender.Bytes()})
+			// This needs to be passed to the Ethereum-Idena Relayer
+			fmt.Println(invitingMerkleTreePath)
+		}
 	case types.SubmitFlipTx:
 		stateDB.SubBalance(sender, fee)
 		stateDB.SubBalance(sender, tx.TipsOrZero())

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -848,7 +848,7 @@ func (chain *Blockchain) ApplyTxOnState(appState *appstate.AppState, tx *types.T
 			(inviteePrevState == state.Invite || inviteePrevState == state.Candidate) {
 			stateDB.AddInvite(sender, 1)
 		}
-		invitingMerkleTreePath, _, _ := offlineDetector.invitingMerkleTree.GetMerklePath(InvitingMerkleTreeContent{h: sender.Bytes()})
+		invitingMerkleTreePath, _, _ := chain.offlineDetector.invitingMerkleTree.GetMerklePath(InvitingMerkleTreeContent{h: sender.Bytes()})
 		// This needs to be passed to the Ethereum-Idena Relayer
 		fmt.Println(invitingMerkleTreePath)
 	case types.SubmitFlipTx:

--- a/core/state/identity_statedb.go
+++ b/core/state/identity_statedb.go
@@ -219,7 +219,7 @@ func (s *IdentityStateDB) createIdentity(addr common.Address) (newobj, prev *sta
 	return newobj, prev
 }
 
-// Retrieve a state account given my the address. Returns nil if not found.
+// Retrieve a state account given by the address. Returns nil if not found.
 func (s *IdentityStateDB) getStateIdentity(addr common.Address) (stateObject *stateApprovedIdentity) {
 	// Prefer 'live' objects.
 	s.lock.Lock()

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -583,7 +583,7 @@ func (s *StateDB) getStateAccount(addr common.Address) (stateObject *stateAccoun
 	return obj
 }
 
-// Retrieve a state account given my the address. Returns nil if not found.
+// Retrieve a state account given by the address. Returns nil if not found.
 func (s *StateDB) getStateIdentity(addr common.Address) (stateObject *stateIdentity) {
 	// Prefer 'live' objects.
 	s.lock.Lock()
@@ -612,7 +612,7 @@ func (s *StateDB) getStateIdentity(addr common.Address) (stateObject *stateIdent
 	return obj
 }
 
-// Retrieve a state account given my the address. Returns nil if not found.
+// Retrieve a state account given by the address. Returns nil if not found.
 func (s *StateDB) getStateGlobal() (stateObject *stateGlobal) {
 	// Prefer 'live' objects.
 	if obj := s.stateGlobal; obj != nil {

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
 	github.com/tendermint/iavl v0.13.2
 	github.com/tendermint/tm-db v0.5.1
+	github.com/uivlis/merkletree v0.2.1-0.20200606114604-cf5cd8b19079
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli v1.22.4
 	github.com/whyrusleeping/go-logging v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -1295,6 +1295,8 @@ github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDH
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/uivlis/merkletree v0.2.1-0.20200606114604-cf5cd8b19079 h1:p5GK2WPEQuS2+9J7usO3I07NiX3na/jhpabzFbTvQbw=
+github.com/uivlis/merkletree v0.2.1-0.20200606114604-cf5cd8b19079/go.mod h1:N51/zbGuWiBfxk1hgO4QM4pICRbC8vbRzrMt6FHXyXA=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=

--- a/node/node.go
+++ b/node/node.go
@@ -240,7 +240,7 @@ func (node *Node) StartWithHeight(height uint64) {
 	node.fp.Initialize()
 	node.ceremony.Initialize(node.blockchain.GetBlock(node.blockchain.Head.Hash()))
 	node.blockchain.ProvideApplyNewEpochFunc(node.ceremony.ApplyNewEpoch)
-	node.offlineDetector.Start(node.blockchain.Head)
+	node.offlineDetector.Start(node.blockchain.Head, node.keyStore)
 	node.consensusEngine.Start()
 	node.pm.Start()
 


### PR DESCRIPTION
In relation to #426. 

There are a couple of things I need to mention:
1. Go signatures and eth signatures are different in that the eth signature is prepended with "\x19Ethereum Signed Message:\n32". I will have to solve this conflict in the relay contract.
2. This has not been properly tested yet, but I needed to highlight the code diffs so that you would be able to comment.
3. The current implementation prints the signature to the console, and it's up to the user to retrieve it.
4. There will also have to be a signature collection mechanism, where the signatures from all the nodes would be collected and relayed to the contract. Not sure, yet, how the mechanics of this would look like.

Looking forward to know what you think.