### PR TITLE
Set profile=server as node default

### DIFF
--- a/config/ipfs.go
+++ b/config/ipfs.go
@@ -20,5 +20,6 @@ func GetDefaultIpfsConfig() *IpfsConfig {
 	return &IpfsConfig{
 		BlockPinThreshold: 0.3,
 		FlipPinThreshold:  0.5,
+		Profile: server,
 	}
 }

--- a/config/ipfs.go
+++ b/config/ipfs.go
@@ -20,6 +20,6 @@ func GetDefaultIpfsConfig() *IpfsConfig {
 	return &IpfsConfig{
 		BlockPinThreshold: 0.3,
 		FlipPinThreshold:  0.5,
-		Profile: server,
+		Profile: "server",
 	}
 }


### PR DESCRIPTION
In hope this is the right way to do it? From my experience, by having this as node default it will benefit all members. VPS providers does not like local lan scanning, why waste time in configuring it? In-home routers struggle with local lan scanning up to the point they are failing. It will be easier for those who need it (2% ?), to turn scanning on, than 98% to turn it off.