### PR TITLE
Trim whitespace around API key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -134,7 +135,7 @@ func (c *Config) SetApiKey() error {
 	if c.RPC.APIKey == "" {
 		apiKeyFile := filepath.Join(c.DataDir, apiKeyFileName)
 		data, _ := ioutil.ReadFile(apiKeyFile)
-		key := string(data)
+		key := strings.TrimSpace(string(data))
 		if key == "" {
 			randomKey, _ := crypto.GenerateKey()
 			key = hex.EncodeToString(crypto.FromECDSA(randomKey)[:16])


### PR DESCRIPTION
Right now it's difficult to set a custom API key via the file because some text editors add a new line symbol at the end of it by default (to comply with the POSIX standard). The client sends the key without the symbol so you get the incorrect key error even though everything looks right.
Stripping the surrounding white space from data that's read from the `api.key` file fixes this.