### PR TITLE
Update rewards.go

### DIFF
--- a/blockchain/rewards.go
+++ b/blockchain/rewards.go
@@ -38,7 +38,7 @@ func rewardValidIdentities(appState *appstate.AppState, config *config.Consensus
 
 func stakeWeight(stake *big.Int) float32 {
 	stakeF, _ := ConvertToFloat(stake).Float64()
-	return float32(math2.Pow(stakeF, 0.9))
+	return float32(math2.Pow(stakeF, 0.75))
 }
 
 func addSuccessfulValidationReward(appState *appstate.AppState, config *config.ConsensusConf,


### PR DESCRIPTION
This change is meant to adjust the staking exponent from 0.9 to 0.75 , to promote more distributed rewards and align incentives with broader participation. As Idena turned out to be a proof-of-human-work Layer 1, not a human DAO layer 1, sublinear stakeweight should prioritize inclusivity - while recognizing that pools and human farms, when compliant with the rules, can contribute positively to the network. Additionally, the coefficient aligns with Vitalik Buterin’s latest proposal for sublinear staking in ethereum research.
