### PR TITLE
Pin release runners for Windows and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,10 @@ defaults:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.17.x]
-        os: ["ubuntu-24.04", "windows-latest", "macos-latest"]
+        os: ["ubuntu-24.04", "windows-2022", "macos-15-intel"]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
## Summary
- pin the Windows release job to `windows-2022`
- pin the macOS release job to `macos-15-intel`
- disable matrix fail-fast to keep all runner results visible

## Why
The release workflow currently depends on `-latest` runner labels. Those labels have moved underneath the workflow, and the macOS release path is still Intel-only. Pinning the release runners makes the job deterministic again without changing application code.

## Notes
This change restores the Intel macOS release path only. It does not add native Apple Silicon release support.